### PR TITLE
Add PHPUnit attributes for PHPUnit 12 compatibility

### DIFF
--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Valet\Brew;
 use Valet\CommandLine;
 use Valet\Filesystem;
@@ -388,6 +389,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     /**
      * @dataProvider supportedPhpLinkPathProvider
      */
+    #[DataProvider('supportedPhpLinkPathProvider')]
     public function test_get_parsed_linked_php_will_return_matches_for_linked_php($path, $matches)
     {
         $getBrewMock = function ($filesystem) {
@@ -405,6 +407,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     /**
      * @dataProvider supportedPhpLinkPathProvider
      */
+    #[DataProvider('supportedPhpLinkPathProvider')]
     public function test_get_linked_php_formula_will_return_linked_php_directory($path, $matches, $expectedLinkFormula)
     {
         $brewMock = Mockery::mock(Brew::class)->makePartial();
@@ -489,7 +492,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
     /**
      * Provider of php links and their expected split matches.
      */
-    public function supportedPhpLinkPathProvider(): array
+    public static function supportedPhpLinkPathProvider(): array
     {
         return [
             [


### PR DESCRIPTION
Required to support `yoast/phpunit-polyfills:^4.0`

Fixes the failing tests in https://github.com/laravel/valet/pull/1512
Explanation at https://github.com/laravel/valet/pull/1512#issuecomment-2691189986